### PR TITLE
Enable server options and http server preference only

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -58,6 +58,13 @@ var conf = exports.conf = {
       env: 'TLS_CA',
       arg: 'tls-ca'
     },
+    secure: {
+      doc: 'Apply tls security layer. Disable if http is preferred',
+      format: Boolean,
+      default: true,
+      env: 'TLS',
+      arg: 'tls'
+    },
     db: {
       doc: 'Microservice database',
       format: String,

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ module.exports = {
   server: async function server(_ref) {
     var dbConnect = _ref.dbConnect,
         schema = _ref.schema,
+        serverOptions = _ref.serverOptions,
         config = _ref.config,
         configOptions = _ref.configOptions,
         _ref$configFiles = _ref.configFiles,
@@ -41,6 +42,7 @@ module.exports = {
     return await (0, _server3.default)({
       dbConnect: dbConnect,
       schema: schema,
+      serverOptions: serverOptions,
       config: (0, _config2.default)(config, configFiles, configOptions),
       routes: routes,
       services: services,

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,6 +8,10 @@ var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
 
 var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
 
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
 var _fs = require('fs');
 
 var _fs2 = _interopRequireDefault(_fs);
@@ -75,13 +79,15 @@ exports.default = async function start(_ref) {
       _ref$swaggerUiOptions = _ref.swaggerUiOptions,
       swaggerUiOptions = _ref$swaggerUiOptions === undefined ? {} : _ref$swaggerUiOptions,
       _ref$loggerOptions = _ref.loggerOptions,
-      loggerOptions = _ref$loggerOptions === undefined ? {} : _ref$loggerOptions;
+      loggerOptions = _ref$loggerOptions === undefined ? {} : _ref$loggerOptions,
+      _ref$serverOptions = _ref.serverOptions,
+      serverOptions = _ref$serverOptions === undefined ? {} : _ref$serverOptions;
 
-  var tls = {
+  var tls = config.get('server.secure') && {
     key: _fs2.default.readFileSync(_path2.default.resolve(__dirname, config.get('server.tlsKey'))),
     cert: _fs2.default.readFileSync(_path2.default.resolve(__dirname, config.get('server.tlsCert')))
   };
-  var app = new _hapi2.default.Server({
+  var app = new _hapi2.default.Server((0, _extends3.default)({
     host: config.get('server.hostname'),
     port: config.get('server.port'),
     tls: tls,
@@ -89,7 +95,7 @@ exports.default = async function start(_ref) {
       request: ['error', 'info', 'warn'],
       log: ['error', 'info', 'warn']
     }
-  });
+  }, serverOptions));
 
   process.on('unhandledRejection', function (error) {
     app.log(['error'], error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctt/crud-api",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A microservice boilerplate",
   "main": "lib/index.js",
   "scripts": {

--- a/src/config.js
+++ b/src/config.js
@@ -43,6 +43,13 @@ export const conf = {
       env: 'TLS_CA',
       arg: 'tls-ca',
     },
+    secure: {
+      doc: 'Apply tls security layer. Disable if http is preferred',
+      format: Boolean,
+      default: true,
+      env: 'TLS',
+      arg: 'tls',
+    },
     db: {
       doc: 'Microservice database',
       format: String,

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ module.exports = {
   server: async({
     dbConnect,
     schema,
+    serverOptions,
     config,
     configOptions,
     configFiles = [],
@@ -21,6 +22,7 @@ module.exports = {
   }) => await server({
     dbConnect,
     schema,
+    serverOptions,
     config: setupConfig(config, configFiles, configOptions),
     routes,
     services,

--- a/src/server.js
+++ b/src/server.js
@@ -22,12 +22,13 @@ export default async function start({
   postRegisterHook = () => {},
   swaggerOptions = {},
   swaggerUiOptions = {},
-  loggerOptions = {}
+  loggerOptions = {},
+  serverOptions = {},
 }: {
   routes: () => Array<({}) => mixed>,
   plugins: Array<mixed>,
 }) {
-  const tls = {
+  const tls = config.get('server.secure') && {
     key: fs.readFileSync(path.resolve(__dirname, config.get('server.tlsKey'))),
     cert: fs.readFileSync(path.resolve(__dirname, config.get('server.tlsCert'))),
   };
@@ -39,6 +40,7 @@ export default async function start({
       request: ['error', 'info', 'warn'],
       log: ['error', 'info', 'warn'],
     },
+    ...serverOptions,
   });
 
   process.on('unhandledRejection', error => {


### PR DESCRIPTION
- [x] Allow [server option](https://hapijs.com/api#-server-options) configuration
- [x] Enable `http` only via environment variables

**Test step:**

For http server...
```
$ TLS=false yarn run bootstrap
```