### PR TITLE
Add health monitoring route by default

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -93,6 +93,7 @@ var init = async function init() {
   });
 
   await app.start();
+  console.log('App runninng on ' + app.info.uri); // eslint-disable-line
 };
 
 init();

--- a/lib/monitoring/health/routes.js
+++ b/lib/monitoring/health/routes.js
@@ -1,0 +1,37 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.ROUTE_NAME = undefined;
+
+var _stringify = require('babel-runtime/core-js/json/stringify');
+
+var _stringify2 = _interopRequireDefault(_stringify);
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var ROUTE_NAME = exports.ROUTE_NAME = 'monitoring/health';
+
+var options = {
+  log: { collect: true },
+  auth: false
+};
+
+exports.default = function () {
+  return {
+    method: 'GET',
+    path: '/' + ROUTE_NAME,
+    options: (0, _extends3.default)({}, options, {
+      tags: ['api']
+    }),
+    handler: async function handler(request, h) {
+      request.log(['/' + ROUTE_NAME], 'Checking application health.');
+      return h.response((0, _stringify2.default)('OK')).code(200).type('application/json');
+    }
+  };
+};

--- a/lib/monitoring/health/routes.js
+++ b/lib/monitoring/health/routes.js
@@ -15,7 +15,7 @@ var _extends3 = _interopRequireDefault(_extends2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var ROUTE_NAME = exports.ROUTE_NAME = 'monitoring/health';
+var ROUTE_NAME = exports.ROUTE_NAME = 'monitoring/healthz';
 
 var options = {
   log: { collect: true },

--- a/lib/server.js
+++ b/lib/server.js
@@ -62,6 +62,10 @@ var _good = require('good');
 
 var _good2 = _interopRequireDefault(_good);
 
+var _routes = require('./monitoring/health/routes');
+
+var _routes2 = _interopRequireDefault(_routes);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 exports.default = async function start(_ref) {
@@ -139,7 +143,7 @@ exports.default = async function start(_ref) {
       options: {}
     });
 
-    routes().map(async function (route) {
+    [_routes2.default].concat((0, _toConsumableArray3.default)(routes))().map(async function (route) {
       return await app.route(route({
         services: serve,
         config: config,

--- a/lib/server.js
+++ b/lib/server.js
@@ -143,7 +143,7 @@ exports.default = async function start(_ref) {
       options: {}
     });
 
-    [_routes2.default].concat((0, _toConsumableArray3.default)(routes))().map(async function (route) {
+    [_routes2.default].concat((0, _toConsumableArray3.default)(routes())).map(async function (route) {
       return await app.route(route({
         services: serve,
         config: config,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctt/crud-api",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A microservice boilerplate",
   "main": "lib/index.js",
   "scripts": {

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -74,6 +74,7 @@ const init = async () => {
   });
 
   await app.start();
+  console.log(`App runninng on ${app.info.uri}`) // eslint-disable-line
 }
 
 init();

--- a/src/monitoring/health/routes.js
+++ b/src/monitoring/health/routes.js
@@ -1,4 +1,4 @@
-export const ROUTE_NAME = 'monitoring/health';
+export const ROUTE_NAME = 'monitoring/healthz';
 
 const options = {
   log: { collect: true },

--- a/src/monitoring/health/routes.js
+++ b/src/monitoring/health/routes.js
@@ -1,0 +1,21 @@
+export const ROUTE_NAME = 'monitoring/health';
+
+const options = {
+  log: { collect: true },
+  auth: false,
+};
+
+export default () => ({
+  method: 'GET',
+  path: `/${ROUTE_NAME}`,
+  options: {
+    ...options,
+    tags: ['api'],
+  },
+  handler: async (request, h) => {
+    request.log([`/${ROUTE_NAME}`], 'Checking application health.');
+    return h.response(JSON.stringify('OK'))
+      .code(200)
+      .type('application/json');
+  }
+});

--- a/src/monitoring/health/routes.test.js
+++ b/src/monitoring/health/routes.test.js
@@ -1,0 +1,58 @@
+import type { JestMockT } from 'jest';
+
+import create, { ROUTE_NAME } from './routes';
+
+describe(`Routes: ${ROUTE_NAME}`, () => {
+  describe(`GET /${ROUTE_NAME}`, () => {
+    const router = create();
+    const responseData = JSON.stringify('OK');
+    const statusCode = 200;
+    const contentType = 'application/json';
+    let mockRequest = { log : null };
+    let mockResponse = null;
+    let mockData: JestMockT = null;
+    let mockStatusCode: JestMockT = null;
+    let mockContentType: JestMockT = null;
+
+    beforeEach(() => {
+      mockData = jest.fn();
+      mockStatusCode = jest.fn();
+      mockContentType = jest.fn();
+
+      mockResponse = {
+        response: mockData,
+        code: mockStatusCode,
+        type: mockContentType,
+      };
+      mockData.mockImplementation(() => mockResponse);
+      mockStatusCode.mockImplementation(() => mockResponse);
+      mockContentType.mockImplementation(() => mockResponse);
+      mockRequest = { log: jest.fn() };
+    });
+
+    it(`sets HTTP method POST on /${ROUTE_NAME} path`, () => {
+      expect(router.method).toBe('GET');
+      expect(router.path).toBe(`/${ROUTE_NAME}`);
+    });
+
+    it(`sets response HTTP status code to ${statusCode} on success`, async () => {
+      await router.handler(mockRequest, mockResponse);
+      expect(mockStatusCode.mock.calls[0][0]).toBe(statusCode);
+    });
+
+    it(`sets response HTTP header Content-Type to ${contentType} on success`, async () => {
+      await router.handler(mockRequest, mockResponse);
+      expect(mockContentType.mock.calls[0][0]).toBe(contentType);
+    });
+
+    it('returns response data on success', async () => {
+      await router.handler(mockRequest, mockResponse);
+      expect(mockData.mock.calls[0][0]).toBe(responseData);
+    });
+
+    it('logs tagged request', async () => {
+      await router.handler(mockRequest, mockResponse);
+      expect(mockRequest.log.mock.calls[0][0]).toEqual([`/${ROUTE_NAME}`]);
+    });
+  });
+});

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,8 @@ import inert from 'inert';
 import requireHttps from 'hapi-require-https';
 import good from 'good';
 
+import checkApplicationHealth from './monitoring/health/routes';
+
 export default async function start({
   dbConnect,
   schema,
@@ -86,7 +88,7 @@ export default async function start({
       options: {}
     });
 
-    routes().map(async route => await app.route(route({
+    [checkApplicationHealth, ...routes()].map(async route => await app.route(route({
       services: serve,
       config,
       validate: Joi,


### PR DESCRIPTION
Application monitoring endpoint. Suitable for [Kubernetes liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-http-request)

- [x] Add `monitoring/healthz` endpoint by default

<img width="1440" alt="Screen Shot 2019-08-29 at 13 31 37" src="https://user-images.githubusercontent.com/1120930/63940549-a297b300-ca61-11e9-8035-cec1b18e2fa7.png">
