### PR TITLE
Delegate environment loading to inheritor 

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -7,6 +7,8 @@ import { schema as mongooseSchema } from './persistence/mongoose';
 import routes from './routes';
 import services from './services';
 
+import _ from './env'; // eslint-disable-line no-unused-vars
+
 const validate = async (/* payload, request*/) => {
   // Apply validation check here...
   return { isValid: true };

--- a/src/env.js
+++ b/src/env.js
@@ -1,5 +1,3 @@
 import dotenv from 'dotenv';
 
-if (process.env.NODE_ENV !== 'test') {
-  dotenv.config({ silent: true });
-}
+dotenv.config({ silent: true });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import _ from './env'; // eslint-disable-line no-unused-vars
 import setupConfig, { baseConfig as env } from './config';
 import server from './server';
 import mysqlConnect from './persistence/mysql';


### PR DESCRIPTION
This PR solved the statefulness smell of `crud-api`. Ideally, `crud-api` should be stateless and environment agnostic. It is left for the inheritor of `crud-api` to setup their environment in whichever way suits them. 